### PR TITLE
intake 0.6.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  # intake and python-snappy currently aren't available on s390x
   noarch: python
   entry_points:
     - intake-server = intake.cli.server.__main__:main
@@ -18,7 +19,7 @@ build:
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
     - setuptools
     - wheel
@@ -29,12 +30,13 @@ requirements:
     - jinja2
     - pyyaml
     - dask
-    - fsspec >=0.7.4
+    - fsspec  >=2021.7.0
    # extra_require - server
-    - requests
     - msgpack-python
     - python-snappy
     - tornado
+   # extra_require - remote
+    - requests
 
 test:
   source_files:
@@ -50,6 +52,8 @@ test:
     - intake-server --help
   requires:
     - pip
+  downstreams:
+    - intake-xarray
 
 about:
   home: https://github.com/ContinuumIO/intake

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.6.3" %}
+{% set version = "0.6.5" %}
 
 package:
   name: intake
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/i/intake/intake-{{ version }}.tar.gz
-  sha256: f64543353f30d9440b953984f78b7a0954e5756d70c64243609d307ba488014f
+  sha256: 06f8044b85e139e2a98c1c5e20c156ba4f4bceed62794742c1648f98dca861a5
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - jinja2
     - pyyaml
     - dask
-    - fsspec  >=2021.7.0
+    - fsspec >=2021.7.0
    # extra_require - server
     - msgpack-python
     - python-snappy


### PR DESCRIPTION
Update intake to 0.6.5

Home url: https://github.com/ContinuumIO/intake
Issues : https://github.com/intake/intake/issues
Requirements: https://github.com/intake/intake/blob/master/setup.py
https://github.com/intake/intake/blob/master/requirements.txt

The package intake is mentioned inside the packages:
intake-xarray |

Actions:
1. Fix python in host
2. Update and reorder run dependencies: `fsspec >=2021.7.0`
3. Add a comment: `intake and python-snappy currently aren't available on s390x`