### PR TITLE
intake 0.6.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   # intake and python-snappy currently aren't available on s390x
-  skip: True  # [py<37 or s390x]
+  skip: True  # [py<38 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - intake-server = intake.cli.server.__main__:main
@@ -30,16 +30,16 @@ requirements:
     - entrypoints
     - jinja2
     - pyyaml
-    - dask-core
+    - dask >=1.0
     - fsspec >=2021.7.0
-   # extra_require - server
+    # extra_require - server
     - msgpack-python
     - python-snappy
     - tornado
-   # extra_require - remote
+    # extra_require - remote
     - requests
   run_constrained:
-   # extra_require - plot
+    # extra_require - plot
     - bokeh
     - hvplot
     - panel >=0.7.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.6.6" %}
+{% set version = "0.6.7" %}
 
 package:
   name: intake
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/i/intake/intake-{{ version }}.tar.gz
-  sha256: 99b31484dbaca0047098cb7bbfb72cea8d6fcb004dea9a5fe145731b1c65a2ca
+  sha256: da77bc4107a4cd5b3a7f669864a2a5b93e4d9c9fc6d9f57668d86435d72e0bec
 
 
 build:


### PR DESCRIPTION
**The upstream source**:
Changelog: https://github.com/intake/intake/blob/0.6.7/docs/source/changelog.rst
Requirements:
- https://github.com/intake/intake/blob/0.6.7/requirements.txt
- https://github.com/intake/intake/blob/0.6.7/setup.py
- conda-forge recipe https://github.com/conda-forge/intake-feedstock/blob/1fece3b02a7128c821a254618a98ac41f9713834/recipe/meta.yaml#L32

**Actions**:
1. Skip `py<38`
2. Use `dask` instead of `dask-core`

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority B | effort: easy | Category: anaconda_affiliated | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 0.6.7
 * Release on PyPi:
    * version: 0.6.7
    * date: 2023-02-13T16:08:24
* [PyPi history](https://pypi.org/project/intake/#history)
 * Popularity: 
    * 3 months downloads: 278493.0
    * All time:  329963 downloads -  intake  0.6.7  Data load and catalog system  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/intake/intake/tree/0.6.7 exists
3. - [x] Check the pinnings
8. - [x] Verify that the `build_number` is correct
9. - [x] has `setuptools`
10. - [x] has `wheel`
11. - [x] `pip` in test
12. - [x] Verify the test section
13. - [x] Verify if the package is `architecture specific`
14. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: LICENSE is present
16. - [x] license_family BSD is present
17. - [x] License: BSD-2-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier          |
|:--------------------|
| BSD-2-Clause        |
| BSD-2-Clause-Patent |
| BSD-2-Clause-Views  |
</details>

**Check dependency issues:**

<details>
../aggregate/intake-feedstock/recipe/meta.yaml
Dependencies: ['jinja2', 'setuptools', 'requests', 'tornado', 'appdirs', 'dask', 'wheel', 'pip', 'pyyaml', 'python', 'entrypoints', 'msgpack-python', 'fsspec >=2021.7.0', 'python-snappy']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 19**


**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/intake-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/intake-feedstock/tree/0.6.7)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/intake)
* [Diff between upstream and feature branch](https://github.com/conda-forge/intake-feedstock/compare/main...AnacondaRecipes:0.6.7)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/intake-feedstock/compare/master...AnacondaRecipes:0.6.7)
* [The last merged PRs](https://github.com/AnacondaRecipes/intake-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.

</details>

```
git clone -b 0.6.7 git@github.com:AnacondaRecipes/intake-feedstock.git
```
