### PR TITLE
Pkg 2111 intake

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   skip: True  # [py<38]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
   entry_points:
     - intake-server = intake.cli.server.__main__:main
     - intake = intake.cli.client.__main__:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,7 +68,7 @@ about:
     * Describe data sets in catalog files for easy reuse and sharing between projects and with others.
     * Share catalog information (and data sets) over the network with the Intake server.
   dev_url: https://github.com/intake/intake
-  doc_url: https://intake.readthedocs.io/en/latest/
+  doc_url: https://intake.readthedocs.io/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.6.8" %}
+{% set version = "0.7.0" %}
 
 package:
   name: intake
@@ -6,8 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/i/intake/intake-{{ version }}.tar.gz
-  sha256: fcda7b572c63da20e5af39c30e0ff28cf7abad4c256e47dc6b5ce22edeb51a56
-
+  sha256: ce3b8bce87f9831823f87936c546f898dbb718985770124c7cc569061726f3b6
 
 build:
   number: 0


### PR DESCRIPTION
intake 0.7.0

**Destination channel:** defaults

### Links

- [PKG-2111](https://anaconda.atlassian.net/browse/PKG-2111) 
- [Upstream repository](https://github.com/intake/intake/tree/0.7.0/intake)
- Relevant dependency PRs:
  - needed for [`intake-xarray`](https://github.com/AnacondaRecipes/intake-xarray-feedstock/pull/4)

### Explanation of changes:

- Although the latest available is version `2.0.5`, building `0.7.0` per request
- Due to failing tests used in old version, will attempt to add upstream tests to latest version


[PKG-2111]: https://anaconda.atlassian.net/browse/PKG-2111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ