### PR TITLE
Pkg 5583 intake 2.0.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,23 +25,25 @@ requirements:
     - wheel
   run:
     - python
-    - appdirs
-    - entrypoints
-    - jinja2
+# - appdirs
+    # - entrypoints
+    # - jinja2
     - pyyaml
-    - dask >=1.0
-    - fsspec >=2021.7.0
-    # extra_require - server
-    - msgpack-python
-    - python-snappy
-    - tornado
-    # extra_require - remote
-    - requests
-  run_constrained:
-    # extra_require - plot
-    - bokeh
-    - hvplot
-    - panel >=0.7.0
+    # - dask >=1.0
+    - fsspec >=2023.0.0
+    - platformdirs
+    - networkx
+  #   # extra_require - server
+  #   - msgpack-python
+  #   - python-snappy
+  #   - tornado
+  #   # extra_require - remote
+  #   - requests
+  # run_constrained:
+  #   # extra_require - plot
+  #   - bokeh
+  #   - hvplot
+  #   - panel >=0.7.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,11 +27,6 @@ requirements:
     - fsspec >=2023.0.0
     - platformdirs
     - networkx
-  run_constrained:
-    # extra_require - plot
-    - bokeh
-    - hvplot
-    - panel >=0.7.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,6 @@ build:
   number: 0
   skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
-  entry_points:
-    - intake-server = intake.cli.server.__main__:main
-    - intake = intake.cli.client.__main__:main
 
 requirements:
   host:
@@ -33,10 +30,10 @@ requirements:
     - fsspec >=2023.0.0
     - platformdirs
     - networkx
-  #   # extra_require - server
-  #   - msgpack-python
-  #   - python-snappy
-  #   - tornado
+  # # extra_require - server
+  # - msgpack-python
+  # - python-snappy
+  # - tornado
   #   # extra_require - remote
   #   - requests
   # run_constrained:
@@ -48,11 +45,14 @@ requirements:
 test:
   imports:
     - intake
-    - intake.auth
     - intake.catalog
+    - intake.container
+    - intake.interface
+    - intake.readers
     - intake.source
   requires:
     - pip
+    - packaging
   commands:
     - pip check
     - intake list --help

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,22 +20,16 @@ requirements:
     - pip
     - setuptools
     - wheel
+    - setuptools_scm
   run:
     - python
-# - appdirs
+    # - appdirs
     # - entrypoints
     # - jinja2
     - pyyaml
-    # - dask >=1.0
     - fsspec >=2023.0.0
     - platformdirs
     - networkx
-  # # extra_require - server
-  # - msgpack-python
-  # - python-snappy
-  # - tornado
-  #   # extra_require - remote
-  #   - requests
   # run_constrained:
   #   # extra_require - plot
   #   - bokeh
@@ -46,17 +40,35 @@ test:
   imports:
     - intake
     - intake.catalog
+    - intake.catalog.entry
+    - intake.catalog.local
     - intake.container
     - intake.interface
+    - intake.interface.catalog
+    - intake.interface.source
     - intake.readers
+    - intake.readers.catalogs
+    - intake.readers.convert
+    - intake.readers.datatypes
+    - intake.readers.entry
+    - intake.readers.importlist
+    - intake.readers.metadata
+    - intake.readers.mixins
+    - intake.readers.namespaces
+    - intake.readers.output
+    - intake.readers.readers
+    - intake.readers.search
+    - intake.readers.transform
+    - intake.readers.user_parameters
     - intake.source
+    - intake.source.base.DataSourceBase
+    - intake.source.base.DataSource
+    - intake.source.derived.AliasSource
+    - intake.source.base.Schema
   requires:
     - pip
-    - packaging
   commands:
     - pip check
-    - intake list --help
-    - intake-server --help
 
 about:
   home: https://github.com/intake/intake

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - fsspec >=2023.0.0
     - platformdirs
     - networkx
+    - packaging
 
 test:
   imports:
@@ -56,7 +57,6 @@ test:
     - intake.source.derived
   requires:
     - pip
-    - packaging
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,13 @@
-{% set version = "0.7.0" %}
+{% set name = "intake" %}
+{% set version = "2.0.7" %}
 
 package:
-  name: intake
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/i/intake/intake-{{ version }}.tar.gz
-  sha256: ce3b8bce87f9831823f87936c546f898dbb718985770124c7cc569061726f3b6
+  url: https://pypi.io/packages/source/i/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 9d3e82cba03e1659b094e3954143f453d54fd64328de322b2e4f11db5f9b1380
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,18 +23,15 @@ requirements:
     - setuptools_scm
   run:
     - python
-    # - appdirs
-    # - entrypoints
-    # - jinja2
     - pyyaml
     - fsspec >=2023.0.0
     - platformdirs
     - networkx
-  # run_constrained:
-  #   # extra_require - plot
-  #   - bokeh
-  #   - hvplot
-  #   - panel >=0.7.0
+  run_constrained:
+    # extra_require - plot
+    - bokeh
+    - hvplot
+    - panel >=0.7.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,12 +61,10 @@ test:
     - intake.readers.transform
     - intake.readers.user_parameters
     - intake.source
-    - intake.source.base.DataSourceBase
-    - intake.source.base.DataSource
-    - intake.source.derived.AliasSource
-    - intake.source.base.Schema
+    - intake.source.derived
   requires:
     - pip
+    - packaging
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - fsspec >=2023.0.0
     - platformdirs
     - networkx
+  # Used here(https://github.com/intake/intake/blob/2.0.7/intake/interface/__init__.py#L7)
     - packaging
 
 test:


### PR DESCRIPTION
intake 2.0.7

**Destination channel:** defaults

### Links

- [PKG-5583](https://anaconda.atlassian.net/browse/PKG-5583) 
- [Upstream repository](https://github.com/intake/intake/tree/2.0.7)
- [Changelog](https://github.com/intake/intake/compare/0.7.0...2.0.7)
- Relevant dependency notes:
  - May or may not be worthy to look at `intake-xarray` and its transitive dependency on `asciitree` through `zarr` that seems outdated and mainly used for testing.

### Explanation of changes:

- **Note for reviewers:**


[PKG-5583]: https://anaconda.atlassian.net/browse/PKG-5583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ