### PR TITLE
intake 2.0.8 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 731d484a002de2f659bb988f406b35037234a35c17b08776d9a5e4838ecf2769
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
 
@@ -39,10 +39,6 @@ test:
     - intake.catalog.utils
     - intake.catalog.zarr
     - intake.config
-    - intake.interface.base
-    - intake.interface.catalog.add
-    - intake.interface.catalog.search
-    - intake.interface.source
     - intake.readers
     - intake.readers.catalogs
     - intake.readers.convert
@@ -73,7 +69,6 @@ test:
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
   requires:
     - pip
-    - panel
 
 about:
   home: https://github.com/intake/intake


### PR DESCRIPTION
intake 2.0.8 

**Destination channel:** Defaults

### Links

- [PKG-11057]
- dev_url:        https://github.com/intake/intake/tree/2.0.8
- conda_forge:    https://github.com/conda-forge/intake-feedstock
- pypi:           https://pypi.org/project/intake/2.0.8
- pypi inspector: https://inspector.pypi.io/project/intake/2.0.8

### Explanation of changes:

- build number increased 0 → 1
- added ANACONDA_ROCKET_ENABLE_PY314 to abs.yaml
- removed several unused test imports in test section


[PKG-11057]: https://anaconda.atlassian.net/browse/PKG-11057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ